### PR TITLE
Ensure Postgres roles exist before dependent services start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - ./services/yts-pg/data:/var/lib/postgresql/data
       - ./services/yts-pg/init:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL","pg_isready -U ${PG_SUPER_USER} -d postgres"]
+      test: ["CMD-SHELL","/docker-entrypoint-initdb.d/99-ensure-users-runtime.sh"]
       <<: *hc
     restart: unless-stopped
     networks:

--- a/services/yts-pg/init/10-init-users.sh
+++ b/services/yts-pg/init/10-init-users.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-psql=(psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB:-postgres}")
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/ensure-users.sh"
+
+: "${POSTGRES_USER:=postgres}"
+: "${POSTGRES_DB:=postgres}"
+
+psql=(psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}")
 
 # Enforce SCRAM-SHA-256 for password encryption
 "${psql[@]}" <<'SQL'
@@ -9,46 +15,4 @@ ALTER SYSTEM SET password_encryption = 'scram-sha-256';
 SELECT pg_reload_conf();
 SQL
 
-init_role_and_db() {
-  local role="$1"
-  local password="$2"
-  local database="$3"
-
-  if [[ -z "${role}" || -z "${password}" || -z "${database}" ]]; then
-    echo "[yts-pg] Missing variables for role/database initialization, skip." >&2
-    return 0
-  fi
-
-  "${psql[@]}" --set=role_name="${role}" --set=role_pwd="${password}" --set=db_name="${database}" <<'SQL'
-DO $do$
-DECLARE
-  role_name text := :'role_name';
-  role_pwd text := :'role_pwd';
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_pwd);
-  ELSE
-    EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', role_name, role_pwd);
-  END IF;
-END
-$do$;
-
-DO $do$
-DECLARE
-  role_name text := :'role_name';
-  db_name text := :'db_name';
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = db_name) THEN
-    EXECUTE format('CREATE DATABASE %I OWNER %I', db_name, role_name);
-  ELSE
-    EXECUTE format('ALTER DATABASE %I OWNER TO %I', db_name, role_name);
-  END IF;
-END
-$do$;
-SQL
-}
-
-init_role_and_db "${PG_USER_KEYCLOAK}" "${PG_PWD_KEYCLOAK}" "${PG_DB_KEYCLOAK}"
-init_role_and_db "${PG_USER_AIRBYTE}" "${PG_PWD_AIRBYTE}" "${PG_DB_AIRBYTE}"
-init_role_and_db "${PG_USER_OM}" "${PG_PWD_OM}" "${PG_DB_OM}"
-init_role_and_db "${PG_USER_TEMPORAL}" "${PG_PWD_TEMPORAL}" "${PG_DB_TEMPORAL}"
+ensure_pg_roles

--- a/services/yts-pg/init/99-ensure-users-runtime.sh
+++ b/services/yts-pg/init/99-ensure-users-runtime.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/ensure-users.sh"
+
+: "${POSTGRES_USER:=postgres}"
+: "${POSTGRES_DB:=postgres}"
+
+if ! pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+  exit 1
+fi
+
+psql=(psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}")
+
+ensure_pg_roles

--- a/services/yts-pg/init/lib/ensure-users.sh
+++ b/services/yts-pg/init/lib/ensure-users.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ensure_pg_role_and_db() {
+  local role="${1:-}"
+  local password="${2:-}"
+  local database="${3:-}"
+
+  if [[ -z "${role}" || -z "${password}" || -z "${database}" ]]; then
+    echo "[yts-pg] Missing variables for role/database initialization, skip." >&2
+    return 0
+  fi
+
+  "${psql[@]}" --set=role_name="${role}" --set=role_pwd="${password}" --set=db_name="${database}" <<'SQL'
+DO $do$
+DECLARE
+  role_name text := :'role_name';
+  role_pwd text := :'role_pwd';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', role_name, role_pwd);
+  ELSE
+    EXECUTE format('ALTER ROLE %I WITH LOGIN PASSWORD %L', role_name, role_pwd);
+  END IF;
+END
+$do$;
+
+DO $do$
+DECLARE
+  role_name text := :'role_name';
+  db_name text := :'db_name';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = db_name) THEN
+    EXECUTE format('CREATE DATABASE %I OWNER %I', db_name, role_name);
+  ELSE
+    EXECUTE format('ALTER DATABASE %I OWNER TO %I', db_name, role_name);
+  END IF;
+END
+$do$;
+SQL
+}
+
+ensure_pg_roles() {
+  ensure_pg_role_and_db "${PG_USER_KEYCLOAK-}" "${PG_PWD_KEYCLOAK-}" "${PG_DB_KEYCLOAK-}"
+  ensure_pg_role_and_db "${PG_USER_AIRBYTE-}" "${PG_PWD_AIRBYTE-}" "${PG_DB_AIRBYTE-}"
+  ensure_pg_role_and_db "${PG_USER_OM-}" "${PG_PWD_OM-}" "${PG_DB_OM-}"
+  ensure_pg_role_and_db "${PG_USER_TEMPORAL-}" "${PG_PWD_TEMPORAL-}" "${PG_DB_TEMPORAL-}"
+}


### PR DESCRIPTION
## Summary
- refactor the Postgres role/database creation logic into a shared helper
- add a runtime script that re-applies the role/database setup and tie it to the Postgres healthcheck
- update docker-compose so dependent services only start after the new healthcheck succeeds

## Testing
- Not run (shellcheck not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ce537ab2f08329802931c6da82205b